### PR TITLE
[JENKINS-60444] Avoid SNI problems while veryfying the certificate

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,6 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+        [ platform: "linux", jdk: "8", jenkins: null ],
+        [ platform: "windows", jdk: "8", jenkins: null ],
+        [ platform: "linux", jdk: "11", jenkins: null, javaLevel: 8 ],
+        [ platform: "windows", jdk: "11", jenkins: null, javaLevel: 8 ]
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,4 @@
 buildPlugin(configurations: [
         [ platform: "linux", jdk: "8", jenkins: null ],
-        [ platform: "windows", jdk: "8", jenkins: null ],
-        [ platform: "linux", jdk: "11", jenkins: null, javaLevel: 8 ],
-        [ platform: "windows", jdk: "11", jenkins: null, javaLevel: 8 ]
+        [ platform: "windows", jdk: "8", jenkins: null ]
 ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>2.9</version>
+    <version>3.46</version>
   </parent>
 
   <artifactId>async-http-client</artifactId>
@@ -62,8 +62,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>1.580.1</jenkins.version>
-    <java.level>6</java.level>
+    <jenkins.version>2.138.4</jenkins.version>
+    <java.level>8</java.level>
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.164.1</jenkins.version>
     <java.level>8</java.level>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.46</version>
+    <version>2.9</version>
   </parent>
 
   <artifactId>async-http-client</artifactId>
@@ -62,8 +62,8 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.164.1</jenkins.version>
-    <java.level>8</java.level>
+    <jenkins.version>1.580.1</jenkins.version>
+    <java.level>6</java.level>
   </properties>
 
   <repositories>

--- a/src/test/java/jenkins/plugins/asynchttpclient/AHCTest.java
+++ b/src/test/java/jenkins/plugins/asynchttpclient/AHCTest.java
@@ -19,6 +19,7 @@ import jenkins.model.Jenkins;
 import org.junit.AssumptionViolatedException;
 import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 import sun.security.provider.certpath.SunCertPathBuilderException;
 
@@ -110,24 +111,26 @@ public class AHCTest {
         }
         fail("Expired certificate accepted");
     }
-
+    
+    @Issue("JENKINS-60444")
     @Test
     public void acceptGoodCertificate() throws Throwable {
+        String host = "https://8.8.8.8";
         try {
             ProxyConfiguration proxy = Jenkins.getInstance().proxy;
-            URL url = new URL("https://letsencrypt.org");
+            URL url = new URL(host);
             HttpURLConnection connection = (HttpURLConnection)
-                    (proxy == null ? url.openConnection() : url.openConnection(proxy.createProxy("letsencrypt.org")));
+                    (proxy == null ? url.openConnection() : url.openConnection(proxy.createProxy(host)));
             connection.setRequestMethod("HEAD");
             connection.setConnectTimeout(30000);
             connection.connect();
         } catch (SSLHandshakeException e) {
-            throw new AssumptionViolatedException("The Root CA for letsencrypt.org is in the JVM trust store", e);
+            throw new AssumptionViolatedException("The Root CA for " + host + " should be in the JVM trust store", e);
         } catch (SocketTimeoutException e) {
-            throw new AssumptionViolatedException("We can connect to letsencrypt.org", e);
+            throw new AssumptionViolatedException("We can not connect to " + host, e);
         }
         AsyncHttpClient ahc = AHC.instance();
-        ListenableFuture<Response> response = ahc.prepareGet("https://letsencrypt.org").execute();
+        ListenableFuture<Response> response = ahc.prepareGet(host).execute();
         assertTrue(response.get().hasResponseStatus());
     }
 }

--- a/src/test/java/jenkins/plugins/asynchttpclient/AHCTest.java
+++ b/src/test/java/jenkins/plugins/asynchttpclient/AHCTest.java
@@ -115,22 +115,22 @@ public class AHCTest {
     @Issue("JENKINS-60444")
     @Test
     public void acceptGoodCertificate() throws Throwable {
-        String host = "https://8.8.8.8";
+        String wellKnownPublicServer = "https://8.8.8.8";
         try {
             ProxyConfiguration proxy = Jenkins.getInstance().proxy;
-            URL url = new URL(host);
+            URL url = new URL(wellKnownPublicServer);
             HttpURLConnection connection = (HttpURLConnection)
-                    (proxy == null ? url.openConnection() : url.openConnection(proxy.createProxy(host)));
+                    (proxy == null ? url.openConnection() : url.openConnection(proxy.createProxy(wellKnownPublicServer)));
             connection.setRequestMethod("HEAD");
             connection.setConnectTimeout(30000);
             connection.connect();
         } catch (SSLHandshakeException e) {
-            throw new AssumptionViolatedException("The Root CA for " + host + " should be in the JVM trust store", e);
+            throw new AssumptionViolatedException("The Root CA for " + wellKnownPublicServer + " should be in the JVM trust store", e);
         } catch (SocketTimeoutException e) {
-            throw new AssumptionViolatedException("We can not connect to " + host, e);
+            throw new AssumptionViolatedException("We can not connect to " + wellKnownPublicServer, e);
         }
         AsyncHttpClient ahc = AHC.instance();
-        ListenableFuture<Response> response = ahc.prepareGet(host).execute();
+        ListenableFuture<Response> response = ahc.prepareGet(wellKnownPublicServer).execute();
         assertTrue(response.get().hasResponseStatus());
     }
 }

--- a/src/test/java/jenkins/plugins/asynchttpclient/AHCTest.java
+++ b/src/test/java/jenkins/plugins/asynchttpclient/AHCTest.java
@@ -115,7 +115,7 @@ public class AHCTest {
     @Issue("JENKINS-60444")
     @Test
     public void acceptGoodCertificate() throws Throwable {
-        String wellKnownPublicServer = "https://8.8.8.8";
+        final String wellKnownPublicServer = "https://8.8.8.8";
         try {
             ProxyConfiguration proxy = Jenkins.getInstance().proxy;
             URL url = new URL(wellKnownPublicServer);


### PR DESCRIPTION
See [[JENKINS-60444]](https://issues.jenkins-ci.org/browse/JENKINS-60444) 

Avoid a failure on PCT because letsencrypt.org now uses SNI and the library doesn't support it. So we use another host to test the good certificates.