### PR TITLE
[JENKINS-66887] Enable jdk11 build on CI for linux and windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+    [platform: 'linux', jdk: '8'],
+    [platform: 'linux', jdk: '11'],
+    [platform: 'windows', jdk: '11'],
+])


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
`recommendedConfigurations` is not building jdk11 anymore. Adding it explicitly.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
