### PR TITLE
Enable jdk11 build on CI for linux and windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+    [platform: 'linux', jdk: '8'],
+    [platform: 'linux', jdk: '11'],
+    [platform: 'windows', jdk: '11'],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.42</version>
+    <version>4.33</version>
   </parent>
 
   <artifactId>async-http-client</artifactId>
@@ -62,7 +62,7 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.277.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -80,7 +80,18 @@
     </pluginRepository>
   </pluginRepositories>
 
-  <dependencies>
+   <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.277.x</artifactId>
+                <version>961.vf0c9f6f59827</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
     <!-- regular dependencies -->
     <dependency>
       <groupId>com.ning</groupId>

--- a/src/main/java/jenkins/plugins/asynchttpclient/AHCUtils.java
+++ b/src/main/java/jenkins/plugins/asynchttpclient/AHCUtils.java
@@ -57,8 +57,8 @@ public final class AHCUtils {
             final ProxyConfiguration proxy = Jenkins.getInstance().proxy;
             proxyServer = new ProxyServer(proxy.name, proxy.port, proxy.getUserName(), proxy.getPassword());
 
-            if (proxy.noProxyHost != null) {
-                for (String s : proxy.noProxyHost.split("[ \t\n,|]+")) {
+            if (proxy.getNoProxyHost() != null) {
+                for (String s : proxy.getNoProxyHost().split("[ \t\n,|]+")) {
                     if (s.length() > 0) {
                         proxyServer.addNonProxyHost(s);
                     }

--- a/src/test/java/jenkins/plugins/asynchttpclient/AHCTest.java
+++ b/src/test/java/jenkins/plugins/asynchttpclient/AHCTest.java
@@ -20,7 +20,7 @@ import org.junit.AssumptionViolatedException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-import sun.security.provider.certpath.SunCertPathBuilderException;
+import java.security.cert.CertPathBuilderException;
 
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
@@ -56,7 +56,7 @@ public class AHCTest {
         ));
     }
 
-    @Test(expected=SunCertPathBuilderException.class)
+    @Test(expected=CertPathBuilderException.class)
     public void failsOnSelfSignedCertificate() throws Throwable {
         try {
             ProxyConfiguration proxy = Jenkins.getInstance().proxy;
@@ -84,7 +84,7 @@ public class AHCTest {
     }
 
 
-    @Test(expected=SunCertPathBuilderException.class)
+    @Test(expected=CertPathBuilderException.class)
     public void failsOnExpiredCertificate() throws Throwable {
         try {
             ProxyConfiguration proxy = Jenkins.getInstance().proxy;


### PR DESCRIPTION
Refiling https://github.com/jenkinsci/async-http-client-plugin/pull/26 as a maintainer so the Jenkinsfile actually gets used.

FYI @aHenryJard @Vlatombe 